### PR TITLE
Fix session storage error

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -1,5 +1,10 @@
 <?php
 session_start();
+// Redirect to login if PHP session has expired or was never set
+if (empty($_SESSION['userID'])) {
+    header("Location: login.html");
+    exit;
+}
 $host      = "137.184.46.194";
 $user      = "cineedsc_sky";
 $password  = "N3ph@ndus";

--- a/dashboard.php
+++ b/dashboard.php
@@ -890,7 +890,7 @@ try {
                           </div>
                           <div class=\"post-row-actions\">
                               <button class=\"btn-sm btn-fulfill\" onclick=\"fulfilPost({$postRow['postID']})\">Fulfilled</button>
-                              <a href=\"edit-post.php?id={$postRow['postID']}\" class=\"btn-sm btn-edit\">Edit</a>
+                              <a href=\"edit-post-form.php?id={$postRow['postID']}\" class=\"btn-sm btn-edit\">Edit</a>
                               <button class=\"btn-sm btn-delete\" onclick=\"showToast(' Delete — connect to backend')\">Delete</button>
                           </div>
                           </div>";

--- a/edit-post-form.php
+++ b/edit-post-form.php
@@ -1,5 +1,5 @@
 <?php
-/* ── edit-post.php — edit form page, pre-filled from database ── */
+/* ── edit-post-form.php — edit form page, pre-filled from database ── */
 
 session_start();
 


### PR DESCRIPTION
Fixed warning messages after navigating to dashboard on a cikeys tab that was left open for 1 hour+:   the PHP session expires on the server side while the JavaScript sessionStorage still thinks you're logged in: so the nav shows "Hi, Dana" and Sign Out correctly, but the PHP queries have nothing to work with. Adding this guard redirects cleanly to login instead of showing warnings. 